### PR TITLE
Fixed teaserpp_python build using PEP-517 standard

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+**/build
+**/_skbuild
+**/*.egg-info
+**/__pycache__
+**/.pytest_cache
+**/.ninja*
+**/CMakeCache.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,12 +59,8 @@ WORKDIR /ros_ws
 
 COPY . /ros_ws/src/multi_lidar_calibration/
 
-RUN cd /ros_ws/src/multi_lidar_calibration/TEASER-plusplus && \
-    mkdir build && \
-    cd build && \
-    cmake -DTEASERPP_PYTHON_VERSION=3.10 .. && \
-    make teaserpp_python && \
-    cd python && pip install .
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install src/multi_lidar_calibration/TEASER-plusplus/
 
 RUN pip install --no-cache-dir --upgrade pip && \
   pip install --no-cache-dir -r src/multi_lidar_calibration/requirements.txt


### PR DESCRIPTION
Fixes #17 

Added:
- [x] `.dockerignore` file to ignore local builds and cache files while building the container

Updated:

- [x] Updated submodule `TEASER-plusplus` to commit `e2f6f17` and use current `master` branch.
- [x] Updated `Dockerfile` to use `PEP-517` standard to install `teaserpp_python` package